### PR TITLE
Add inspector panel

### DIFF
--- a/packages/extension/src/util/theme-colors.ts
+++ b/packages/extension/src/util/theme-colors.ts
@@ -1,0 +1,91 @@
+import * as path from 'node:path'
+import * as vscode from 'vscode'
+
+interface Theme {
+  colors?: Record<string, string>
+  tokenColors?: Array<{
+    scope?: string | string[]
+    settings?: { foreground?: string }
+  }>
+}
+
+const defaultColor = 'var(--vscode-editor-foreground)'
+const themeTokenColors = [
+  'text', // For HTML text content
+  'string', // For HTML attribute values
+  'punctuation', // For HTML <>/= characters
+  'entity.name.tag', // For HTML tags
+  'entity.other.attribute-name', // For HTML attribute names
+] as const
+
+type ThemeTokenColor = (typeof themeTokenColors)[number]
+type ThemeTokenColorMap = Partial<Record<ThemeTokenColor, string>>
+
+/**
+ * Finds the URI of the active color theme's definition file.
+ * It searches through all extensions to find the one that contributes the current theme,
+ * and then constructs the path to the theme's JSON file.
+ */
+function findThemeFileUri(): vscode.Uri | undefined {
+  const currentTheme = vscode.workspace.getConfiguration('workbench').get('colorTheme')
+
+  for (const extension of vscode.extensions.all) {
+    const theme = extension.packageJSON.contributes?.themes?.find((theme: any) => theme.label === currentTheme || theme.id === currentTheme)
+    if (theme) {
+      return vscode.Uri.file(path.join(extension.extensionPath, theme.path))
+    }
+  }
+  return undefined
+}
+
+// Regular expression to find comments, but not inside strings.
+// It handles single-line, multi-line, and trailing comments.
+function stripJsonComments(jsonString: string): string {
+  return jsonString.replace(
+    /\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g,
+    (match, group) => (group ? '' : match),
+  )
+}
+
+function normalizeThemeColors(theme: Theme): Record<string, string> {
+  const colors = theme.colors || {}
+  for (const tokenColor of theme.tokenColors || []) {
+    if (tokenColor.scope && tokenColor.settings?.foreground) {
+      const scopes = Array.isArray(tokenColor.scope) ? tokenColor.scope : [tokenColor.scope]
+
+      for (const scope of scopes) {
+        const combinedScopes = scope.split(',')
+        for (const combinedScope of combinedScopes) {
+          colors[combinedScope.trim()] = tokenColor.settings.foreground
+        }
+      }
+    }
+  }
+  return colors
+}
+
+/**
+ * Retrieves the current theme's syntax highlighting colors by parsing the theme file.
+ */
+export async function getThemeColors(): Promise<ThemeTokenColorMap> {
+  const tokenColorMap: ThemeTokenColorMap = {}
+  const themeFileUri = findThemeFileUri()
+  if (!themeFileUri) { return tokenColorMap }
+
+  const themeContent = await vscode.workspace.fs.readFile(themeFileUri)
+
+  try {
+    const theme = JSON.parse(stripJsonComments(themeContent.toString())) as Theme
+    const colors = normalizeThemeColors(theme)
+    for (const token of themeTokenColors) {
+      const [bestMatch] = Object.keys(colors)
+        .filter(k => k === token || k.endsWith(`.${token}`) || (k.includes(token) && k.includes('.html')))
+        .sort((a, b) => a.length - b.length)
+      tokenColorMap[token] = bestMatch && colors[bestMatch] || defaultColor
+    }
+  }
+  catch (error) {
+    console.error('Error parsing theme file', error)
+  }
+  return tokenColorMap as ThemeTokenColorMap
+}

--- a/packages/web-view-vite/package.json
+++ b/packages/web-view-vite/package.json
@@ -10,6 +10,7 @@
     "@kobalte/core": "0.13.10",
     "@kobalte/utils": "^0.9.1",
     "@solid-primitives/event-listener": "^2.4.3",
+    "@solid-primitives/map": "^0.7.2",
     "@trpc/client": "^11.4.3",
     "@trpc/server": "^11.4.3",
     "@vscode/webview-ui-toolkit": "^1.4.0",

--- a/packages/web-view-vite/src/App.tsx
+++ b/packages/web-view-vite/src/App.tsx
@@ -52,11 +52,16 @@ export function App() {
           style={{ visibility: firstPatchReceived() ? 'visible' : 'hidden' }}
           class="absolute h-full w-full flex flex-col"
         >
-          <div class="flex-2">
+          <div
+            classList={{
+              'h-full': !showInspector(),
+              'h-2/3': showInspector(),
+            }}
+          >
             {shadowHost}
           </div>
           <Show when={showInspector()}>
-            <div class="flex-1 overflow-y-hidden border-t border-[var(--vscode-panel-border)]">
+            <div class="h-1/3 overflow-y-hidden border-t border-[var(--vscode-panel-border)]">
               <Inspector />
             </div>
           </Show>

--- a/packages/web-view-vite/src/App.tsx
+++ b/packages/web-view-vite/src/App.tsx
@@ -3,6 +3,7 @@ import { createSignal } from 'solid-js'
 import { createColorTheme } from './lib/color-theme'
 import { createDomReplica } from './lib/create-dom-replica'
 import { Toolbar } from './components/Toolbar'
+import { Inspector } from './components/Inspector'
 
 // Importing the router type from the server file
 
@@ -32,9 +33,11 @@ export const {
   stylesAreLoading,
 } = createDomReplica()
 
+export const [showInspector, setShowInspector] = createSignal(false)
+
 export function App() {
   return (
-    <div class="fixed inset-0">
+    <div class="fixed inset-0 flex flex-col">
       <div style={{ visibility: firstPatchReceived() ? 'visible' : 'hidden' }}>
         <Toolbar />
       </div>
@@ -47,9 +50,12 @@ export function App() {
         </div>
         <div
           style={{ visibility: firstPatchReceived() ? 'visible' : 'hidden' }}
-          class="absolute h-full w-full"
+          class="absolute h-full w-full flex flex-col"
         >
-          {shadowHost}
+          <div class={`flex-grow ${showInspector() ? 'h-2/3' : 'h-full'}`}>
+            {shadowHost}
+          </div>
+          {showInspector() && <Inspector />}
         </div>
       </div>
     </div>

--- a/packages/web-view-vite/src/App.tsx
+++ b/packages/web-view-vite/src/App.tsx
@@ -1,5 +1,5 @@
 import * as webviewToolkit from '@vscode/webview-ui-toolkit'
-import { createSignal } from 'solid-js'
+import { Show, createSignal } from 'solid-js'
 import { createColorTheme } from './lib/color-theme'
 import { createDomReplica } from './lib/create-dom-replica'
 import { Toolbar } from './components/Toolbar'
@@ -52,10 +52,14 @@ export function App() {
           style={{ visibility: firstPatchReceived() ? 'visible' : 'hidden' }}
           class="absolute h-full w-full flex flex-col"
         >
-          <div class={`flex-grow ${showInspector() ? 'h-2/3' : 'h-full'}`}>
+          <div class="flex-2">
             {shadowHost}
           </div>
-          {showInspector() && <Inspector />}
+          <Show when={showInspector()}>
+            <div class="flex-1 overflow-y-hidden border-t border-[var(--vscode-panel-border)]">
+              <Inspector />
+            </div>
+          </Show>
         </div>
       </div>
     </div>

--- a/packages/web-view-vite/src/App.tsx
+++ b/packages/web-view-vite/src/App.tsx
@@ -20,6 +20,7 @@ import { client } from './lib/panel-client'
     .register(webviewToolkit.vsCodeButton({ prefix }))
     .register(webviewToolkit.vsCodeCheckbox({ prefix }))
     .register(webviewToolkit.vsCodeProgressRing({ prefix }))
+    .register(webviewToolkit.vsCodeTextField({ prefix }))
 }
 
 // TODO put these into a context provider

--- a/packages/web-view-vite/src/App.tsx
+++ b/packages/web-view-vite/src/App.tsx
@@ -2,6 +2,7 @@ import * as webviewToolkit from '@vscode/webview-ui-toolkit'
 import { Show, createSignal } from 'solid-js'
 import { createColorTheme } from './lib/color-theme'
 import { createDomReplica } from './lib/create-dom-replica'
+import { createInspectorHeight } from './lib/inspector-height'
 import { Toolbar } from './components/Toolbar'
 import { Inspector } from './components/Inspector'
 import { Resizer } from './components/Resizer'
@@ -34,8 +35,7 @@ export const {
   stylesAreLoading,
 } = createDomReplica()
 
-export const [showInspector, setShowInspector] = createSignal(false)
-export const [inspectorHeight, setInspectorHeight] = createSignal(300) // Default height of 300px
+export const inspector = createInspectorHeight()
 
 export function App() {
   return (
@@ -56,16 +56,16 @@ export function App() {
         >
           <div
             style={{
-              height: showInspector() ? `calc(100% - ${inspectorHeight()}px)` : '100%',
+              height: inspector.isVisible() ? `calc(100% - ${inspector.height()}px)` : '100%',
             }}
           >
             {shadowHost}
           </div>
-          <Show when={showInspector()}>
-            <Resizer onResize={setInspectorHeight} />
+          <Show when={inspector.isVisible()}>
+            <Resizer onResize={inspector.setHeight} />
             <div
               class="overflow-y-hidden"
-              style={{ height: `${inspectorHeight()}px` }}
+              style={{ height: `${inspector.height()}px` }}
             >
               <Inspector />
             </div>

--- a/packages/web-view-vite/src/App.tsx
+++ b/packages/web-view-vite/src/App.tsx
@@ -1,11 +1,12 @@
 import * as webviewToolkit from '@vscode/webview-ui-toolkit'
-import { Show, createSignal } from 'solid-js'
+import { Show, createResource, createSignal } from 'solid-js'
 import { createColorTheme } from './lib/color-theme'
 import { createDomReplica } from './lib/create-dom-replica'
 import { createInspectorHeight } from './lib/inspector-height'
 import { Toolbar } from './components/Toolbar'
 import { Inspector } from './components/Inspector'
 import { Resizer } from './components/Resizer'
+import { client } from './lib/panel-client'
 
 // Importing the router type from the server file
 
@@ -38,8 +39,15 @@ export const {
 export const inspector = createInspectorHeight()
 
 export function App() {
+  const [themeColors] = createResource(
+    () => client.getVSCodeThemeAsCss.query(),
+  )
+
   return (
     <div class="fixed inset-0 flex flex-col">
+      <style>
+        {`:root { ${themeColors()} }`}
+      </style>
       <div style={{ visibility: firstPatchReceived() ? 'visible' : 'hidden' }}>
         <Toolbar />
       </div>

--- a/packages/web-view-vite/src/App.tsx
+++ b/packages/web-view-vite/src/App.tsx
@@ -4,6 +4,7 @@ import { createColorTheme } from './lib/color-theme'
 import { createDomReplica } from './lib/create-dom-replica'
 import { Toolbar } from './components/Toolbar'
 import { Inspector } from './components/Inspector'
+import { Resizer } from './components/Resizer'
 
 // Importing the router type from the server file
 
@@ -34,6 +35,7 @@ export const {
 } = createDomReplica()
 
 export const [showInspector, setShowInspector] = createSignal(false)
+export const [inspectorHeight, setInspectorHeight] = createSignal(300) // Default height of 300px
 
 export function App() {
   return (
@@ -53,15 +55,18 @@ export function App() {
           class="absolute h-full w-full flex flex-col"
         >
           <div
-            classList={{
-              'h-full': !showInspector(),
-              'h-2/3': showInspector(),
+            style={{
+              height: showInspector() ? `calc(100% - ${inspectorHeight()}px)` : '100%',
             }}
           >
             {shadowHost}
           </div>
           <Show when={showInspector()}>
-            <div class="h-1/3 overflow-y-hidden border-t border-[var(--vscode-panel-border)]">
+            <Resizer onResize={setInspectorHeight} />
+            <div
+              class="overflow-y-hidden"
+              style={{ height: `${inspectorHeight()}px` }}
+            >
               <Inspector />
             </div>
           </Show>

--- a/packages/web-view-vite/src/components/Inspector.tsx
+++ b/packages/web-view-vite/src/components/Inspector.tsx
@@ -1,9 +1,13 @@
-import { Show, createSignal } from 'solid-js'
+import { Show, createEffect, createSignal } from 'solid-js'
 import { makeEventListener } from '@solid-primitives/event-listener'
 import { ReactiveWeakMap } from '@solid-primitives/map'
 import { shadowHost } from '../App'
 import { type DOMTree, getNewDomTree } from '../lib/inspector-dom-tree'
+import { createInspectorSearch } from '../lib/inspector-search'
 import { TreeNode } from './TreeNode'
+import { SearchToolbar } from './SearchToolbar'
+
+export const search = createInspectorSearch()
 
 export function Inspector() {
   const [hoveredRect, setHoveredRect] = createSignal<DOMRect | null>(null)
@@ -21,35 +25,51 @@ export function Inspector() {
 
   // highlight the element under the mouse
   makeEventListener(shadowHost, 'mousemove', (e) => {
-    const el = shadowHost?.shadowRoot?.elementFromPoint(e.clientX, e.clientY)
-    setHoveredRect(el?.getBoundingClientRect() ?? null)
+    const el = shadowHost.shadowRoot?.elementFromPoint(e.clientX, e.clientY)
+    if (el?.closest('body')) {
+      setHoveredRect(el?.getBoundingClientRect() ?? null)
+    }
   })
 
   // select the element under the mouse
   makeEventListener(shadowHost, 'click', (e) => {
     e.preventDefault()
     e.stopPropagation()
-    const el = shadowHost?.shadowRoot?.elementFromPoint(e.clientX, e.clientY)
+    const el = shadowHost.shadowRoot?.elementFromPoint(e.clientX, e.clientY)
     setSelectedElement(el ?? null)
+  })
+
+  // select and highlight the current element matching the search query
+  createEffect(() => {
+    if (search.matchedNodes().length > 0) {
+      const el = search.matchedNodes()[search.currentNodeIndex()]
+      if (el) {
+        setSelectedElement(el)
+        setHoveredRect(el.getBoundingClientRect())
+      }
+    }
   })
 
   return (
     <div class="h-full w-full flex flex-col">
-      <div class="bg-[var(--vscode-panel-background)] text-[var(--vscode-panel-foreground)] h-full w-full overflow-scroll pt-4 pb-4">
-        <div class="font-(family-name:--theme-font-family) font-(--theme-font-weight) text-(length:--theme-font-size) leading-(--theme-line-height)">
-          <Show when={domTree()} keyed={true}>
-            {tree => (
-              <TreeNode
-                {...tree}
-                onHover={setHoveredRect}
-                collapsedStates={collapsedStates}
-                selectedNode={selectedElement()}
-                onSelect={setSelectedElement}
-              />
-            )}
-          </Show>
-        </div>
-      </div>
+      <Show when={domTree()} keyed={true}>
+        {tree => (
+          <>
+            <SearchToolbar tree={tree} />
+            <div class="bg-(--vscode-panel-background) text-(--vscode-panel-foreground) h-full w-full overflow-scroll pt-2 pb-4">
+              <div class="font-(family-name:--theme-font-family) font-(--theme-font-weight) text-(length:--theme-font-size) leading-(--theme-line-height)">
+                <TreeNode
+                  {...tree}
+                  onHover={setHoveredRect}
+                  collapsedStates={collapsedStates}
+                  selectedNode={selectedElement()}
+                  onSelect={setSelectedElement}
+                />
+              </div>
+            </div>
+          </>
+        )}
+      </Show>
       {hoveredRect() && (
         <div
           class="fixed pointer-events-none bg-[var(--vscode-editorLightBulbAutoFix-foreground)] opacity-60 transition-all duration-100 z-50"

--- a/packages/web-view-vite/src/components/Inspector.tsx
+++ b/packages/web-view-vite/src/components/Inspector.tsx
@@ -56,7 +56,7 @@ export function Inspector() {
 
   return (
     <>
-      <div class="bg-[var(--vscode-editor-background)] text-[var(--vscode-editor-foreground)] h-full w-full overflow-scroll p-4">
+      <div class="bg-[var(--vscode-panel-background)] text-[var(--vscode-panel-foreground)] h-full w-full overflow-scroll p-4">
         <Show when={domTree()} keyed={true}>
           {tree => (
             <TreeNode

--- a/packages/web-view-vite/src/components/Inspector.tsx
+++ b/packages/web-view-vite/src/components/Inspector.tsx
@@ -1,4 +1,4 @@
-import { Show, createEffect, createSignal, onCleanup } from 'solid-js'
+import { Show, createSignal } from 'solid-js'
 import { makeEventListener } from '@solid-primitives/event-listener'
 import { ReactiveWeakMap } from '@solid-primitives/map'
 import { shadowHost } from '../App'
@@ -32,8 +32,6 @@ function parseDOMTree(node: Element): DOMTree {
 }
 
 export function Inspector() {
-  const [hoveredRect, setHoveredRect] = createSignal<DOMRect | null>(null)
-
   function getNewDomTree() {
     const shadowRoot = shadowHost?.shadowRoot
     if (!shadowRoot) {
@@ -44,6 +42,7 @@ export function Inspector() {
     return tree
   }
 
+  const [hoveredRect, setHoveredRect] = createSignal<DOMRect | null>(null)
   const [domTree, setDomTree] = createSignal<DOMTree | null>(getNewDomTree(), { equals: false })
   const collapsedStates = new ReactiveWeakMap<Element, boolean>()
 

--- a/packages/web-view-vite/src/components/Inspector.tsx
+++ b/packages/web-view-vite/src/components/Inspector.tsx
@@ -1,0 +1,81 @@
+import { Show, createEffect, createSignal, onCleanup } from 'solid-js'
+import { shadowHost } from '../App'
+import type { DOMTree } from './TreeNode'
+import { TreeNode } from './TreeNode'
+
+function parseDOMTree(node: Element): DOMTree {
+  // Get all direct text nodes, excluding whitespace-only nodes
+  const textNodes = Array.from(node.childNodes)
+    .filter(child =>
+      child.nodeType === Node.TEXT_NODE
+      && child.textContent?.trim() !== '',
+    )
+    .map(node => node.textContent?.trim())
+    .filter(Boolean)
+    .join(' ')
+
+  // Get all attributes
+  const attributes = Array.from(node.attributes || [])
+    .map(attr => ({ name: attr.name, value: attr.value }))
+
+  return {
+    tagName: node.tagName.toLowerCase(),
+    childTrees: Array.from(node.children).map(child => parseDOMTree(child)),
+    textNodes,
+    attributes,
+    getBoundingClientRect: () => node.getBoundingClientRect(),
+  }
+}
+
+export function Inspector() {
+  const [hoveredRect, setHoveredRect] = createSignal<DOMRect | null>(null)
+  const [domTree, setDomTree] = createSignal<DOMTree | null>(null, { equals: false })
+
+  // Set up mutation observer to track DOM changes
+  createEffect(() => {
+    const shadowRoot = shadowHost?.shadowRoot
+    if (!shadowRoot) { return }
+
+    const observer = new MutationObserver(() => {
+      const tree = parseDOMTree(shadowRoot.querySelector('body')!)
+      setDomTree(tree)
+    })
+
+    observer.observe(shadowRoot, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      characterData: true,
+    })
+
+    setDomTree(parseDOMTree(shadowRoot.querySelector('body')!))
+
+    onCleanup(() => observer.disconnect())
+  })
+
+  return (
+    <>
+      <div class="bg-[var(--vscode-editor-background)] text-[var(--vscode-editor-foreground)] h-1/3 w-full overflow-auto p-4 border-t border-[var(--vscode-panel-border)]">
+        <Show when={domTree()}>
+          {tree => (
+            <TreeNode
+              {...tree()}
+              onHover={setHoveredRect}
+            />
+          )}
+        </Show>
+      </div>
+      {hoveredRect() && (
+        <div
+          class="fixed pointer-events-none bg-[var(--vscode-editorLightBulbAutoFix-foreground)] opacity-60 transition-all duration-100 z-50"
+          style={{
+            top: `${hoveredRect()!.top}px`,
+            left: `${hoveredRect()!.left}px`,
+            width: `${hoveredRect()!.width}px`,
+            height: `${hoveredRect()!.height}px`,
+          }}
+        />
+      )}
+    </>
+  )
+}

--- a/packages/web-view-vite/src/components/Resizer.tsx
+++ b/packages/web-view-vite/src/components/Resizer.tsx
@@ -1,0 +1,36 @@
+import { createSignal } from 'solid-js'
+import { makeEventListener } from '@solid-primitives/event-listener'
+
+interface ResizerProps {
+  onResize: (height: number) => void
+}
+
+export function Resizer(props: ResizerProps) {
+  const [isDragging, setIsDragging] = createSignal(false)
+
+  function handleMouseDown(e: MouseEvent) {
+    setIsDragging(true)
+    e.preventDefault()
+  }
+
+  // Use makeEventListener for mousemove
+  makeEventListener(document, 'mousemove', (e) => {
+    if (!isDragging()) { return }
+    props.onResize(window.innerHeight - e.clientY)
+  })
+
+  // Use makeEventListener for mouseup
+  makeEventListener(document, 'mouseup', () => {
+    setIsDragging(false)
+  })
+
+  return (
+    <div
+      class="relative z-1 h-2 cursor-ns-resize -mt-1 -mb-1"
+      onMouseDown={handleMouseDown}
+      style={{ 'background-color': 'transparent' }}
+    >
+      <hr class="mt-1 border-t border-[var(--vscode-panel-border)]" />
+    </div>
+  )
+}

--- a/packages/web-view-vite/src/components/SearchToolbar.tsx
+++ b/packages/web-view-vite/src/components/SearchToolbar.tsx
@@ -1,0 +1,66 @@
+import ChevronDown from 'lucide-solid/icons/chevron-down'
+import ChevronUp from 'lucide-solid/icons/chevron-up'
+import X from 'lucide-solid/icons/x'
+import Search from 'lucide-solid/icons/search'
+
+import { Show, createEffect } from 'solid-js'
+import type { DOMTree } from '../lib/inspector-dom-tree'
+import { search } from './Inspector'
+
+export function SearchToolbar(props: { tree: DOMTree }) {
+  // update the search results when the tree changes
+  createEffect(() => {
+    search.handleSearch(search.searchQuery(), props.tree)
+  })
+
+  return (
+    <div class="flex items-center gap-2 p-2">
+      <ui-test-visualizer-text-field
+        class="grow"
+        placeholder="Find by string or selector"
+        onInput={(e: Event & { currentTarget: HTMLInputElement }) => {
+          search.handleSearch(e.currentTarget.value, props.tree)
+        }}
+        onKeyDown={(e: KeyboardEvent) => {
+          if (e.key === 'Enter') {
+            search.handleNext()
+          }
+        }}
+        value={search.searchQuery()}
+      >
+        <span slot="start"><Search class="h-4 w-4 text-muted-foreground" /></span>
+      </ui-test-visualizer-text-field>
+      <div class="flex items-center gap-2">
+        <ui-test-visualizer-button
+          appearance="icon"
+          aria-label="Previous result"
+          onClick={() => search.handlePrev()}
+          disabled={search.matchedNodes().length < 2}
+        >
+          <ChevronUp class="h-4 w-4" />
+        </ui-test-visualizer-button>
+        <ui-test-visualizer-button
+          appearance="icon"
+          aria-label="Next result"
+          onClick={() => search.handleNext()}
+          disabled={search.matchedNodes().length < 2}
+        >
+          <ChevronDown class="h-4 w-4" />
+        </ui-test-visualizer-button>
+        <Show when={search.matchedNodes().length > 0}>
+          <span class="px-2 text-sm text-muted-foreground text-center">
+            {`${search.currentNodeIndex() + 1} of ${search.matchedNodes().length}`}
+          </span>
+        </Show>
+        <ui-test-visualizer-button
+          appearance="icon"
+          aria-label="Clear search"
+          onClick={() => search.handleClearSearch()}
+          disabled={!search.searchQuery()}
+        >
+          <X class="h-4 w-4" />
+        </ui-test-visualizer-button>
+      </div>
+    </div>
+  )
+}

--- a/packages/web-view-vite/src/components/Toolbar.tsx
+++ b/packages/web-view-vite/src/components/Toolbar.tsx
@@ -3,7 +3,7 @@ import Moon from 'lucide-solid/icons/moon'
 import RefreshCw from 'lucide-solid/icons/refresh-cw'
 import Code from 'lucide-solid/icons/code'
 import type { ParentProps } from 'solid-js'
-import { firstPatchReceived, refreshShadow, setShowInspector, showInspector, theme, toggleTheme } from '../App'
+import { firstPatchReceived, inspector, refreshShadow, theme, toggleTheme } from '../App'
 import { StyleIcon, StylePicker } from './StylePicker'
 import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip'
 
@@ -14,7 +14,7 @@ export function Toolbar() {
       style={{ visibility: firstPatchReceived() ? 'visible' : 'hidden' }}
     >
       <ToolbarButton
-        onClick={() => setShowInspector(!showInspector())}
+        onClick={inspector.toggle}
         label="Toggle Inspector"
       >
         <Code />

--- a/packages/web-view-vite/src/components/Toolbar.tsx
+++ b/packages/web-view-vite/src/components/Toolbar.tsx
@@ -1,8 +1,9 @@
 import Sun from 'lucide-solid/icons/sun'
 import Moon from 'lucide-solid/icons/moon'
 import RefreshCw from 'lucide-solid/icons/refresh-cw'
+import Code from 'lucide-solid/icons/code'
 import type { ParentProps } from 'solid-js'
-import { firstPatchReceived, refreshShadow, theme, toggleTheme } from '../App'
+import { firstPatchReceived, refreshShadow, setShowInspector, showInspector, theme, toggleTheme } from '../App'
 import { StyleIcon, StylePicker } from './StylePicker'
 import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip'
 
@@ -12,6 +13,12 @@ export function Toolbar() {
       class="flex gap-2 p-2"
       style={{ visibility: firstPatchReceived() ? 'visible' : 'hidden' }}
     >
+      <ToolbarButton
+        onClick={() => setShowInspector(!showInspector())}
+        label="Toggle Inspector"
+      >
+        <Code />
+      </ToolbarButton>
       <ToolbarButton
         onClick={refreshShadow}
         label="Refresh Panel HTML"

--- a/packages/web-view-vite/src/components/TreeNode.tsx
+++ b/packages/web-view-vite/src/components/TreeNode.tsx
@@ -1,0 +1,88 @@
+import { For, createSignal } from 'solid-js'
+
+export interface DOMTree {
+  tagName: string
+  textNodes: string | undefined
+  attributes: { name: string, value: string }[]
+  childTrees: DOMTree[]
+  getBoundingClientRect: () => DOMRect
+}
+
+interface TreeNodeProps extends DOMTree {
+  depth?: number
+  onHover: (rect: DOMRect | null) => void
+}
+
+export function TreeNode(props: TreeNodeProps) {
+  const [isCollapsed, setIsCollapsed] = createSignal(false)
+  const depth = props.depth || 0
+  const indent = '  '.repeat(depth)
+  const hasChildren = props.childTrees.length > 0
+
+  const renderAttributes = () => {
+    return props.attributes.map(attr => (
+      <span class="text-[var(--vscode-symbolIcon-propertyForeground)] whitespace-nowrap">
+        <span class="ml-1 ">{attr.name}</span>
+        {attr.value !== '' && (
+          <span>="<span class="text-[var(--vscode-symbolIcon-stringForeground)]">{attr.value.trim()}</span>"</span>
+        )}
+      </span>
+    ))
+  }
+
+  return (
+    <div class="font-mono">
+      <div
+        class="flex items-center hover:bg-[var(--vscode-list-hoverBackground)] cursor-pointer"
+        onMouseEnter={() => props.onHover(props.getBoundingClientRect())}
+        onMouseLeave={() => props.onHover(null)}
+      >
+        <span class="inline-flex items-center">
+          {indent}
+          {hasChildren && (
+            <span
+              class="cursor-pointer inline-block w-4 select-none text-[var(--vscode-editor-foreground)] opacity-60"
+              onClick={() => setIsCollapsed(!isCollapsed())}
+            >
+              {isCollapsed() ? '▶' : '▼'}
+            </span>
+          )}
+          {!hasChildren && <span class="w-4" />}
+          <span class="text-[var(--vscode-symbolIcon-classForeground)]">&lt;{props.tagName}</span>
+          {props.attributes.length > 0 && renderAttributes()}
+          <span class="text-[var(--vscode-symbolIcon-classForeground)]">&gt;</span>
+          {(props.textNodes?.length ?? 0) < 20 && (
+            <span class="text-[var(--vscode-editor-foreground)] whitespace-nowrap">{props.textNodes?.trim()}</span>
+          )}
+          {(props.textNodes?.length ?? 0) >= 20 && (
+            <div class="text-[var(--vscode-editor-foreground)]">{props.textNodes?.trim()}</div>
+          )}
+          {isCollapsed() && <span>&hellip;</span>}
+          {((!hasChildren && props.textNodes) || isCollapsed()) && (
+            <span class="text-[var(--vscode-symbolIcon-classForeground)]">&lt;/{props.tagName}&gt;</span>
+          )}
+        </span>
+      </div>
+      {!isCollapsed() && hasChildren && (
+        <>
+          <div class="ml-4">
+            <For each={props.childTrees}>
+              {child => (
+                <TreeNode
+                  {...child}
+                  depth={depth + 1}
+                  onHover={props.onHover}
+                />
+              )}
+            </For>
+          </div>
+          <div>
+            {indent}
+            <span class="w-4 inline-block" />
+            <span class="text-[var(--vscode-symbolIcon-classForeground)]">&lt;/{props.tagName}&gt;</span>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/packages/web-view-vite/src/components/TreeNode.tsx
+++ b/packages/web-view-vite/src/components/TreeNode.tsx
@@ -2,6 +2,8 @@ import type { ReactiveWeakMap } from '@solid-primitives/map'
 import { For, Show, createEffect, on } from 'solid-js'
 import { type DOMTree, containsNode } from '../lib/inspector-dom-tree'
 
+import { search } from './Inspector'
+
 interface TreeNodeProps extends DOMTree {
   depth?: number
   onHover: (rect: DOMRect | null) => void
@@ -14,6 +16,9 @@ export function TreeNode(props: TreeNodeProps) {
   let container: HTMLDivElement | undefined
 
   const isCollapsed = () => props.collapsedStates.get(props.node) ?? false
+  const isMatching = () => search.matchedNodes().includes(props.node)
+  const isSelected = () => props.node === props.selectedNode
+
   function setIsCollapsed(value: boolean) {
     props.collapsedStates.set(props.node, value)
   }
@@ -56,12 +61,13 @@ export function TreeNode(props: TreeNodeProps) {
         ref={container}
         class="relative min-w-9/10 box-content scroll-m-10"
         classList={{
-          'bg-(--vscode-editor-selectionBackground) shadow-[100vw_0_0_var(--vscode-editor-selectionBackground)]': props.node === props.selectedNode,
-          'hover:bg-(--vscode-list-hoverBackground) hover:shadow-[100vw_0_0_var(--vscode-list-hoverBackground)]': props.node !== props.selectedNode,
+          'bg-(--vscode-editor-selectionBackground) shadow-[100vw_0_0_var(--vscode-editor-selectionBackground)]': isSelected(),
+          'bg-(--vscode-searchEditor-findMatchBackground) shadow-[100vw_0_0_var(--vscode-searchEditor-findMatchBackground)]': isMatching() && !isSelected(),
+          'hover:bg-(--vscode-list-hoverBackground) hover:shadow-[100vw_0_0_var(--vscode-list-hoverBackground)]': !isSelected() && !isMatching(),
         }}
         onMouseEnter={() => props.onHover(props.getBoundingClientRect())}
         onMouseLeave={() => props.onHover(null)}
-        onClick={() => props.onSelect(props.node !== props.selectedNode ? props.node : null)}
+        onClick={() => props.onSelect(isSelected() ? null : props.node)}
         style={{ 'padding-left': paddingLeft }}
       >
         {hasChildren && props.depth && (

--- a/packages/web-view-vite/src/index.css
+++ b/packages/web-view-vite/src/index.css
@@ -54,3 +54,18 @@
     --radius: 0.5rem;
   }
 }
+
+@layer utilities {
+  .animate-highlight > div > span[data-highlight] {
+    animation: highlight 1.5s cubic-bezier(0.55, 0, 1, 0.45);
+  }
+
+  @keyframes highlight {
+    from {
+      background-color: var(--vscode-editor-stackFrameHighlightBackground);
+    }
+    to {
+      background-color: transparent;
+    }
+  }
+}

--- a/packages/web-view-vite/src/lib/create-dom-replica.tsx
+++ b/packages/web-view-vite/src/lib/create-dom-replica.tsx
@@ -55,10 +55,6 @@ export function createDomReplica() {
     // instead of overlapping the UI outside the shadow (i.e. the toolbar)
     htmlEl.style.transform = 'scale(1)'
 
-    // Add extra padding to the bottom because the toolbar reduces the scrollable height,
-    // cutting off the bottom of tall UIs
-    htmlEl.style.paddingBottom = '80px'
-
     setReplicaHtmlEl(htmlEl)
   }
 

--- a/packages/web-view-vite/src/lib/inspector-dom-tree.ts
+++ b/packages/web-view-vite/src/lib/inspector-dom-tree.ts
@@ -1,0 +1,75 @@
+import isEqual from 'lodash/isEqual'
+import { shadowHost } from '../App'
+
+export interface DOMTree {
+  tagName: string
+  textNodes: string | undefined
+  attributes: { name: string, value: string }[]
+  childTrees: DOMTree[]
+  shadowTrees: DOMTree[] | null
+  getBoundingClientRect: () => DOMRect
+  node: Element
+  isChanged: () => boolean
+}
+
+export function parseDOMTree(node: Element, previousTree: DOMTree | null): DOMTree {
+  // Get all direct text nodes, excluding whitespace-only nodes
+  const textNodes = Array.from(node.childNodes)
+    .filter(child =>
+      child.nodeType === Node.TEXT_NODE
+      && child.textContent?.trim() !== '',
+    )
+    .map(node => node.textContent?.trim())
+    .filter(Boolean)
+    .join(' ')
+
+  // Get all attributes
+  const attributes = Array.from(node.attributes || [])
+    .map(attr => ({ name: attr.name, value: attr.value }))
+
+  const childTrees = Array.from(node.children)
+    .map((child, idx) => parseDOMTree(child, previousTree?.childTrees?.[idx] ?? null))
+  const shadowTrees = node.shadowRoot
+    ? Array.from(node.shadowRoot.children).map((child, idx) => parseDOMTree(child, previousTree?.shadowTrees?.[idx] ?? null))
+    : null
+
+  let isChanged = !!previousTree && !isEqual(previousTree, {
+    childTrees,
+    shadowTrees,
+    textNodes,
+    attributes,
+  })
+
+  return {
+    tagName: node.tagName.toLowerCase(),
+    childTrees,
+    shadowTrees,
+    textNodes,
+    attributes,
+    node,
+    isChanged: () => {
+      const changed = isChanged
+      isChanged = false
+      return changed
+    },
+    getBoundingClientRect: () => node.getBoundingClientRect(),
+  }
+}
+
+export function getNewDomTree(previousTree: DOMTree | null) {
+  const shadowRoot = shadowHost?.shadowRoot
+  if (!shadowRoot) {
+    return null
+  }
+  const tree = parseDOMTree(shadowRoot.querySelector('body')!, previousTree)
+  return tree
+}
+
+export function containsNode(trees: DOMTree[] | null, node: Element): boolean {
+  for (const tree of trees || []) {
+    if (tree.node === node) { return true }
+    if (tree.childTrees?.length && containsNode(tree.childTrees, node)) { return true }
+    if (tree.shadowTrees?.length && containsNode(tree.shadowTrees, node)) { return true }
+  }
+  return false
+}

--- a/packages/web-view-vite/src/lib/inspector-height.ts
+++ b/packages/web-view-vite/src/lib/inspector-height.ts
@@ -1,0 +1,26 @@
+import { createSignal } from 'solid-js'
+
+const STORAGE_KEY = 'ui-test-visualizer.inspector-height'
+const DEFAULT_HEIGHT = 300
+
+export function createInspectorHeight() {
+  // Get initial height from storage or use default
+  const initialHeight = Number(localStorage.getItem(STORAGE_KEY)) || DEFAULT_HEIGHT
+
+  const [height, setHeight] = createSignal(initialHeight)
+
+  // Wrapper for setHeight that also persists to storage
+  function updateHeight(newHeight: number) {
+    // Clamp height between 0 and 80% of viewport height
+    const clampedHeight = Math.max(0, Math.min(newHeight, window.innerHeight * 0.8))
+    setHeight(clampedHeight)
+    localStorage.setItem(STORAGE_KEY, clampedHeight.toString())
+  }
+
+  return {
+    isVisible: () => height() > 0,
+    height,
+    setHeight: updateHeight,
+    toggle: () => updateHeight(height() > 0 ? 0 : initialHeight),
+  }
+}

--- a/packages/web-view-vite/src/lib/inspector-search.tsx
+++ b/packages/web-view-vite/src/lib/inspector-search.tsx
@@ -1,0 +1,69 @@
+import { createSignal } from 'solid-js'
+import { shadowHost } from '../App'
+import type { DOMTree } from './inspector-dom-tree'
+
+function searchTextInsideTree(tree: DOMTree, query: string): Element[] {
+  const nodes: Element[] = []
+  if (tree.textNodes?.toLowerCase().includes(query.toLowerCase())) {
+    nodes.push(tree.node)
+  }
+  for (const child of tree.childTrees) {
+    nodes.push(...searchTextInsideTree(child, query))
+  }
+  return nodes
+}
+
+export function createInspectorSearch() {
+  const [searchQuery, setSearchQuery] = createSignal('')
+  const [matchedNodes, setMatchedNodes] = createSignal<Element[]>([])
+  const [currentNodeIndex, setCurrentNodeIndex] = createSignal(0)
+
+  const handleSearch = (query: string, tree: DOMTree | null) => {
+    setSearchQuery(query)
+
+    if (!query || !shadowHost.shadowRoot || !tree) {
+      setMatchedNodes([])
+      setCurrentNodeIndex(0)
+      return
+    }
+
+    let nodes: Element[] = []
+    // First try to find nodes by CSS selector
+    try {
+      nodes = Array.from(shadowHost.shadowRoot.querySelectorAll(query))
+    }
+    catch (e) {}
+    // If no nodes found, try to find nodes by text content
+    if (nodes.length === 0) {
+      nodes = searchTextInsideTree(tree, query)
+    }
+    setMatchedNodes(nodes)
+    setCurrentNodeIndex(0)
+  }
+
+  const handleClearSearch = () => {
+    handleSearch('', null)
+  }
+
+  const handleNext = () => {
+    if (matchedNodes().length === 0) { return }
+    const nextIndex = (currentNodeIndex() + 1) % matchedNodes().length
+    setCurrentNodeIndex(nextIndex)
+  }
+
+  const handlePrev = () => {
+    if (matchedNodes().length === 0) { return }
+    const prevIndex = (currentNodeIndex() - 1 + matchedNodes().length) % matchedNodes().length
+    setCurrentNodeIndex(prevIndex)
+  }
+
+  return {
+    searchQuery,
+    matchedNodes,
+    currentNodeIndex,
+    handleSearch,
+    handleClearSearch,
+    handleNext,
+    handlePrev,
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,6 +455,9 @@ importers:
       '@solid-primitives/event-listener':
         specifier: ^2.4.3
         version: 2.4.3(solid-js@1.9.7)
+      '@solid-primitives/map':
+        specifier: ^0.7.2
+        version: 0.7.2(solid-js@1.9.7)
       '@trpc/client':
         specifier: ^11.4.3
         version: 11.4.3(@trpc/server@11.4.3(typescript@5.8.3))(typescript@5.8.3)
@@ -3110,6 +3113,11 @@ packages:
     peerDependencies:
       solid-js: ^1.6.12
 
+  '@solid-primitives/map@0.7.2':
+    resolution: {integrity: sha512-sXK/rS68B4oq3XXNyLrzVhLtT1pnimmMUahd2FqhtYUuyQsCfnW058ptO1s+lWc2k8F/3zQSNVkZ2ifJjlcNbQ==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
   '@solid-primitives/media@2.3.0':
     resolution: {integrity: sha512-7+C3wfbWnGE/WPoNsqcp/EeOP2aNNB92RCpsWhBth8E5lZo/J+rK6jMb7umVsK0zguT8HBpeXp1pFyFbcsHStA==}
     peerDependencies:
@@ -3157,6 +3165,11 @@ packages:
 
   '@solid-primitives/trigger@1.2.0':
     resolution: {integrity: sha512-sW4/3cDXSjYQampn8CIFZ11BlxgNf2li8r2fXnb3b3YWE6RdZZCl8PhvpPF38Gzl0CnryrbTPJWM7OIkseCDgQ==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/trigger@1.2.2':
+    resolution: {integrity: sha512-IWoptVc0SWYgmpBPpCMehS5b07+tpFcvw15tOQ3QbXedSYn6KP8zCjPkHNzMxcOvOicTneleeZDP7lqmz+PQ6g==}
     peerDependencies:
       solid-js: ^1.6.12
 
@@ -10719,6 +10732,11 @@ snapshots:
       '@solid-primitives/trigger': 1.2.0(solid-js@1.9.7)
       solid-js: 1.9.7
 
+  '@solid-primitives/map@0.7.2(solid-js@1.9.7)':
+    dependencies:
+      '@solid-primitives/trigger': 1.2.2(solid-js@1.9.7)
+      solid-js: 1.9.7
+
   '@solid-primitives/media@2.3.0(solid-js@1.9.7)':
     dependencies:
       '@solid-primitives/event-listener': 2.4.3(solid-js@1.9.7)
@@ -10773,6 +10791,11 @@ snapshots:
   '@solid-primitives/trigger@1.2.0(solid-js@1.9.7)':
     dependencies:
       '@solid-primitives/utils': 6.3.0(solid-js@1.9.7)
+      solid-js: 1.9.7
+
+  '@solid-primitives/trigger@1.2.2(solid-js@1.9.7)':
+    dependencies:
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.7)
       solid-js: 1.9.7
 
   '@solid-primitives/utils@6.3.0(solid-js@1.9.7)':


### PR DESCRIPTION
Hi there, I find your extension extremely useful and I'd love to make it even better by allowing the ability to navigate the DOM tree. The main reason is that while adding/fixing tests with testing-library, being able to inspect the DOM to find the right `role` or aria attribute is extremely valuable (and so much better than `screen.debug`).

This PR is a first implementation of an inspector panel. I'm not that familiar with Solid so there might be things you might wanna tweak, but it does work and would love your feedback before spending more time on it.